### PR TITLE
edges(l; length) -> edges(l; order)

### DIFF
--- a/src/Chain.jl
+++ b/src/Chain.jl
@@ -25,7 +25,7 @@ Base.nameof(::Chain) = "Chain Lattice"
 
 # NOTE: OneTo is faster than 1:L
 Lattices.sites(::Chain{L}) where L = Base.OneTo(L)
-Lattices.edges(::Chain{L, BC}; length::Int=1) where {L, BC} = EdgesIterator{L, length, BC}()
+Lattices.edges(::Chain{L, BC}; order::Int=1) where {L, BC} = EdgesIterator{L, order, BC}()
 
 struct EdgesIterator{L, order, BC} end
 

--- a/src/LatticeIterators.jl
+++ b/src/LatticeIterators.jl
@@ -11,9 +11,11 @@ Returns an iterator for all sites on the lattice.
 function sites end
 
 """
-    edges(lattice; [length=1]) -> iterator
+    edges(lattice; [order=1]) -> iterator
 
-Returns an iterator for all edges of `length` on the lattice.
+Returns an iterator for all edges of the lattice of a given `order`.
+For example, `order = 1` means nearest neighbors and `order = 2`
+means next-nearest neighbors.
 """
 function edges end
 

--- a/src/LatticeIterators.jl
+++ b/src/LatticeIterators.jl
@@ -14,8 +14,8 @@ function sites end
     edges(lattice; [order=1]) -> iterator
 
 Returns an iterator for all edges of the lattice of a given `order`.
-For example, `order = 1` means nearest neighbors and `order = 2`
-means next-nearest neighbors.
+For example, `order = 1` means nearest neighbor edges and `order = 2`
+means next-nearest neighbors edges.
 """
 function edges end
 

--- a/src/LatticeIterators.jl
+++ b/src/LatticeIterators.jl
@@ -38,7 +38,7 @@ Returns an iterator of all faces.
 function faces end
 
 """
-    neighbors(lattice, s; length=1) -> iterator
+    neighbors(lattice, s; order=1) -> iterator
 
 Returns an iterator of the surrounding sites of given site `s`.
 """

--- a/src/hyperrect.jl
+++ b/src/hyperrect.jl
@@ -17,11 +17,11 @@ function sites(ltc::HyperRect)
     Base.CartesianIndices((Base.OneTo(k + 1) for k in size(ltc))...)
 end
 
-function edges(ltc::HyperRect; length=1)
+function edges(ltc::HyperRect; order=1)
     error("Not Implemented Yet")
 end
 
-function neighbors(::HyperRect{N, Periodic, Shape}, P::CartesianIndex; length=1) where {N, Shape}
+function neighbors(::HyperRect{N, Periodic, Shape}, P::CartesianIndex; order=1) where {N, Shape}
     @boundscheck all(x->x>0, Tuple(P)) || error("Lattice configuration position starts from 1")
     hyper_rect_neighbors(P, Shape, Val(length))
 end

--- a/src/square/edges.jl
+++ b/src/square/edges.jl
@@ -1,12 +1,12 @@
-function Lattices.edges(lattice::Square; length::Int=1)
-    if isodd(length)
-        k = (length + 1) ÷ 2
+function Lattices.edges(lattice::Square; order::Int=1)
+    if isodd(order)
+        k = (order + 1) ÷ 2
         FusedEdgesIterator(
             EdgesIterator{:vertical, k}(lattice),
             EdgesIterator{:horizontal, k}(lattice)
         )
     else
-        k = length ÷ 2
+        k = order ÷ 2
         FusedEdgesIterator(
             EdgesIterator{:upright, k}(lattice),
             EdgesIterator{:upleft, k}(lattice)


### PR DESCRIPTION
`length` is misleading/wrong here. The next-nearest neighbor edges of a square lattice do not have `length = 2` but `length = sqrt(2)`. It seems much better to let the user specify the `order`, i.e. `order = 1` = edges to nearest neighbors, `order = 2` = edges to next-nearest neighbors, etc. Generally, I think it's strange to let the user specify the real space `length`.

Of course, for some lattices, sites have different length nearest neighbor edges. So maybe we need some other functionality for these cases as well.